### PR TITLE
Clear locked balance on withdrawal

### DIFF
--- a/contracts/ve.sol
+++ b/contracts/ve.sol
@@ -1055,6 +1055,7 @@ contract ve is IERC721, IERC721Enumerable, IERC721Metadata {
 
         _locked.end = 0;
         _locked.amount = 0;
+        locked[_tokenId] = _locked;
         uint256 supply_before = supply;
         supply = supply_before - value;
 


### PR DESCRIPTION
As `_locked` is now `memory` it needs to be set on the state variable. Same behaviour as before in `ve.vy`
```
    _locked: LockedBalance = self.locked[_tokenId]
    assert block.timestamp >= _locked.end, "The lock didn't expire"
    value: uint256 = convert(_locked.amount, uint256)

    old_locked: LockedBalance = _locked
    _locked.end = 0
    _locked.amount = 0
    self.locked[_tokenId] = _locked
 ```