### PR TITLE
add address to create_lock

### DIFF
--- a/contracts/ve.sol
+++ b/contracts/ve.sol
@@ -993,10 +993,11 @@ contract ve is IERC721, IERC721Enumerable, IERC721Metadata {
         _deposit_for(msg.sender, _tokenId, _value, 0, _locked, DepositType.DEPOSIT_FOR_TYPE, false);
     }
 
-    /// @notice Deposit `_value` tokens for `msg.sender` and lock for `_lock_duration`
+    /// @notice Deposit `_value` tokens for `_to` and lock for `_lock_duration`
     /// @param _value Amount to deposit
-    /// _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
-    function create_lock(uint256 _value, uint256 _lock_duration) external nonreentrant returns (uint256) {
+    /// @param _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
+    /// @param _to Address to deposit
+    function _create_lock(uint256 _value, uint256 _lock_duration, address _to) internal returns (uint256) {
         uint256 unlock_time = (block.timestamp + _lock_duration) / WEEK * WEEK; // Locktime is rounded down to weeks
 
         assert(_value > 0); // dev: need non-zero value
@@ -1005,10 +1006,25 @@ contract ve is IERC721, IERC721Enumerable, IERC721Metadata {
 
         ++tokenId;
         uint256 _tokenId = tokenId;
-        _mint(msg.sender, _tokenId);
+        _mint(_to, _tokenId);
 
-        _deposit_for(msg.sender, _tokenId, _value, unlock_time, locked[_tokenId], DepositType.CREATE_LOCK_TYPE, false);
+        _deposit_for(_to, _tokenId, _value, unlock_time, locked[_tokenId], DepositType.CREATE_LOCK_TYPE, false);
         return _tokenId;
+    }
+
+    /// @notice Deposit `_value` tokens for `_to` and lock for `_lock_duration`
+    /// @param _value Amount to deposit
+    /// @param _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
+    /// @param _to Address to deposit
+    function create_lock_for(uint256 _value, uint256 _lock_duration, address _to) external nonreentrant returns (uint256) {
+        return _create_lock(_value, _lock_duration, _to);
+    }
+
+    /// @notice Deposit `_value` tokens for `msg.sender` and lock for `_lock_duration`
+    /// @param _value Amount to deposit
+    /// @param _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
+    function create_lock(uint256 _value, uint256 _lock_duration) external nonreentrant returns (uint256) {
+        return _create_lock(_value, _lock_duration, msg.sender);
     }
 
     /// @notice Deposit `_value` additional tokens for `_tokenId` without modifying the unlock time

--- a/contracts/ve.vy
+++ b/contracts/ve.vy
@@ -793,12 +793,11 @@ def deposit_for(_tokenId: uint256, _value: uint256):
 
 @external
 @nonreentrant('lock')
-def create_lock(_value: uint256, _lock_duration: uint256, _addr: address = msg.sender) -> uint256:
+def create_lock(_value: uint256, _lock_duration: uint256) -> uint256:
     """
-    @notice Deposit `_value` tokens for `_addr` and lock for `_lock_duration`
+    @notice Deposit `_value` tokens for `msg.sender` and lock for `_lock_duration`
     @param _value Amount to deposit
     @param _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
-    @param _addr Address to deposit
     """
     unlock_time: uint256 = (block.timestamp + _lock_duration) / WEEK * WEEK  # Locktime is rounded down to weeks
 
@@ -809,11 +808,11 @@ def create_lock(_value: uint256, _lock_duration: uint256, _addr: address = msg.s
     self.tokenId += 1
     _tokenId: uint256 = self.tokenId
 
-    self._mint(_addr, _tokenId)
+    self._mint(msg.sender, _tokenId)
 
     _locked: LockedBalance = self.locked[_tokenId]
 
-    self._deposit_for(_addr, _tokenId, _value, unlock_time, _locked, CREATE_LOCK_TYPE)
+    self._deposit_for(msg.sender, _tokenId, _value, unlock_time, _locked, CREATE_LOCK_TYPE)
     return _tokenId
 
 

--- a/contracts/ve.vy
+++ b/contracts/ve.vy
@@ -793,11 +793,12 @@ def deposit_for(_tokenId: uint256, _value: uint256):
 
 @external
 @nonreentrant('lock')
-def create_lock(_value: uint256, _lock_duration: uint256) -> uint256:
+def create_lock(_value: uint256, _lock_duration: uint256, _addr: address = msg.sender) -> uint256:
     """
-    @notice Deposit `_value` tokens for `msg.sender` and lock for `_lock_duration`
+    @notice Deposit `_value` tokens for `_addr` and lock for `_lock_duration`
     @param _value Amount to deposit
     @param _lock_duration Number of seconds to lock tokens for (rounded down to nearest week)
+    @param _addr Address to deposit
     """
     unlock_time: uint256 = (block.timestamp + _lock_duration) / WEEK * WEEK  # Locktime is rounded down to weeks
 
@@ -808,11 +809,11 @@ def create_lock(_value: uint256, _lock_duration: uint256) -> uint256:
     self.tokenId += 1
     _tokenId: uint256 = self.tokenId
 
-    self._mint(msg.sender, _tokenId)
+    self._mint(_addr, _tokenId)
 
     _locked: LockedBalance = self.locked[_tokenId]
 
-    self._deposit_for(msg.sender, _tokenId, _value, unlock_time, _locked, CREATE_LOCK_TYPE)
+    self._deposit_for(_addr, _tokenId, _value, unlock_time, _locked, CREATE_LOCK_TYPE)
     return _tokenId
 
 


### PR DESCRIPTION
To facilitate protocol integration, add `address` for lock

```
def create_lock(_value: uint256, _lock_duration: uint256, _addr: address = msg.sender) -> uint256:
```