### PR TITLE
feat: add gauge registration to BaseV1GaugeFactory

### DIFF
--- a/contracts/BaseV1-gauges.sol
+++ b/contracts/BaseV1-gauges.sol
@@ -527,8 +527,33 @@ contract Gauge {
 
 contract BaseV1GaugeFactory {
     address public last_gauge;
+    address[] public gauges;    
+    uint256 public gaugesLength;
+    mapping(address => address[]) public gaugesByPoolAddress;
+    mapping(address => address[]) public gaugesByBribeAddress;
+    mapping(address => address[]) public gaugesByVeAddress;
+    mapping(address => address[]) public gaugesByVoterAddress;
+    mapping(address => uint256) public gaugesByPoolAddressLength;
+    mapping(address => uint256) public gaugesByBribeAddressLength;
+    mapping(address => uint256) public gaugesByVeAddressLength;
+    mapping(address => uint256) public gaugesByVoterAddressLength;
+    
     function createGauge(address _pool, address _bribe, address _ve) external returns (address) {
         last_gauge = address(new Gauge(_pool, _bribe, _ve, msg.sender));
+        registerGauge(last_gauge, _pool, _bribe, _ve, msg.sender);
         return last_gauge;
+    }
+    
+    function registerGauge(address _gauge, address _pool, address _bribe, address _ve, address _voter) internal {
+        gauges.push(_gauge);
+        gaugesByPoolAddress[_pool].push(_gauge);
+        gaugesByBribeAddress[_bribe].push(_gauge);
+        gaugesByVeAddress[_ve].push(_gauge);
+        gaugesByVoterAddress[_voter].push(_gauge);
+        gaugesLength++;
+        gaugesByPoolAddressLength[_pool]++;
+        gaugesByBribeAddressLength[_bribe]++;
+        gaugesByVeAddressLength[_ve]++;
+        gaugesByVoterAddressLength[_voter]++;
     }
 }

--- a/test/base.js
+++ b/test/base.js
@@ -344,6 +344,49 @@ describe("core", function () {
     expect(await gauge.totalSupply()).to.equal(pair_1000);
     expect(await gauge.earned(ve.address, owner.address)).to.equal(0);
   });
+    
+  it("fetch gauges with filters", async function () {
+    [voter] = await ethers.getSigners(1);
+    const gauges_factory_contract = await ethers.getContractFactory("BaseV1GaugeFactory");
+    const gauges_factory_instance = await gauges_factory_contract.deploy();
+    await gauges_factory_instance.deployed();
+    
+    expect(await gauges_factory_instance.gaugesLength()).to.equal(0);
+    expect(await gauges_factory_instance.gaugesByPoolAddressLength(pair.address)).to.equal(0);
+    expect(await gauges_factory_instance.gaugesByBribeAddressLength(pair.address)).to.equal(0);
+    expect(await gauges_factory_instance.gaugesByVeAddressLength(pair.address)).to.equal(0);
+    expect(await gauges_factory_instance.gaugesByVoterAddressLength(pair.address)).to.equal(0);
+    
+    await gauges_factory_instance.createGauge(pair.address, bribe.address, ve.address);
+    await gauges_factory_instance.createGauge(pair2.address, bribe.address, ve.address);
+    await gauges_factory_instance.createGauge(pair3.address, bribe.address, ve.address);
+    
+    const gauge_1 = await gauges_factory_instance.gauges(0)
+    const gauge_2 = await gauges_factory_instance.gauges(1)
+    const gauge_3 = await gauges_factory_instance.gauges(2)
+      
+    expect(await gauges_factory_instance.gaugesLength()).to.equal(3);
+    expect(await gauges_factory_instance.gaugesByPoolAddressLength(pair.address)).to.equal(1);
+    expect(await gauges_factory_instance.gaugesByBribeAddressLength(bribe.address)).to.equal(3);
+    expect(await gauges_factory_instance.gaugesByVeAddressLength(ve.address)).to.equal(3);
+    expect(await gauges_factory_instance.gaugesByVoterAddressLength(voter.address)).to.equal(3);
+      
+    expect(await gauges_factory_instance.gaugesByPoolAddress(pair.address, 0)).to.equal(gauge_1);
+    expect(await gauges_factory_instance.gaugesByPoolAddress(pair2.address, 0)).to.equal(gauge_2);
+    expect(await gauges_factory_instance.gaugesByPoolAddress(pair3.address, 0)).to.equal(gauge_3);
+    
+    expect(await gauges_factory_instance.gaugesByBribeAddress(bribe.address, 0)).to.equal(gauge_1);
+    expect(await gauges_factory_instance.gaugesByBribeAddress(bribe.address, 1)).to.equal(gauge_2);
+    expect(await gauges_factory_instance.gaugesByBribeAddress(bribe.address, 2)).to.equal(gauge_3);
+      
+    expect(await gauges_factory_instance.gaugesByVeAddress(ve.address, 0)).to.equal(gauge_1);
+    expect(await gauges_factory_instance.gaugesByVeAddress(ve.address, 1)).to.equal(gauge_2);
+    expect(await gauges_factory_instance.gaugesByVeAddress(ve.address, 2)).to.equal(gauge_3);
+
+    expect(await gauges_factory_instance.gaugesByVoterAddress(voter.address, 0)).to.equal(gauge_1);
+    expect(await gauges_factory_instance.gaugesByVoterAddress(voter.address, 1)).to.equal(gauge_2);
+    expect(await gauges_factory_instance.gaugesByVoterAddress(voter.address, 2)).to.equal(gauge_3);
+  });
 
   it("deploy BaseV1Factory gauge owner2", async function () {
     const pair_1000 = ethers.BigNumber.from("1000000000");


### PR DESCRIPTION
- Add gauge registration to base gauge factory
- Currently there is no way to fetch all gauges made by the factory or gauges for a specific pool, bribe, or ve token
   - You can fetch gauges and pools scoped to a voter, however there is no way to fetch globally scoped information
- Added length tracking for filter maps
   - This will allow front-end integrators to filter and paginate results
   - Without length tracking integrating contracts would need to implement try/catch logic
   - Length tracking is not a requirement (feel free to remove it) but it's nice-to-have (BaseV1Factory supports this)