### PR TITLE
refactor: expose factory and gauge factory addresses in voter

### DIFF
--- a/contracts/BaseV1-voter.sol
+++ b/contracts/BaseV1-voter.sol
@@ -507,9 +507,9 @@ contract Bribe {
 
 contract BaseV1Voter {
     address public immutable _ve; // the ve token that governs these contracts
-    address internal immutable factory; // the BaseV1Factory
+    address public immutable factory; // the BaseV1Factory
     address internal immutable base;
-    address internal immutable gaugefactory;
+    address public immutable gaugefactory;
 
     uint public totalWeight; // total voting weight
 


### PR DESCRIPTION
Given a `ve` address I am trying to fetch protocol data on-chain:

```
struct ProtocolMetadata {
    address veAddress;
    address veUnderlyingAddress;
    address voterAddress;
    address poolsFactoryAddress;
    address gaugesFactoryAddress;
    address routerAddress;
    address minterAddress;
}
```

This is mostly possible if everything is properly configured, with the exception of gauge factory address.

It would be nice to expose factory address and gauge factory address in voter.

```
veUnderlyingAddress:  ve.token
voterAddress:         ve.voter
routerAddress:        veUnderlying.router (currently this is incorrect in testnet)
poolsFactoryAddress:  router.factory || voter.factory (currently internal)
gaugesFactoryAddress: voter.gaugeFactory (currently internal)
minterAddress:        underlying.minter (currently address(0))
```