### PR TITLE
perf: remove bytes conversion

### DIFF
--- a/contracts/BaseV1-core.sol
+++ b/contracts/BaseV1-core.sol
@@ -526,7 +526,7 @@ contract BaseV1Pair {
             abi.encode(
                 keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
                 keccak256(bytes(name)),
-                keccak256(bytes('1')),
+                keccak256('1'),
                 block.chainid,
                 address(this)
             )


### PR DESCRIPTION
saves a bit of gas cuz the conversion screws up solidity's constant folding engine

more context here: https://twitter.com/transmissions11/status/1476067435715256326?s=20